### PR TITLE
It is better to use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rscpi"
 description = "Rust library for USBTMC"
-homepage = "https://github.com/danchitnis/rscpi"
+repository = "https://github.com/danchitnis/rscpi"
 license = "MIT"
 version = "0.1.0"
 edition = "2021"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.